### PR TITLE
Rebase 0001-apt-1.2.12-Fix-musl-build.patch

### DIFF
--- a/apt-pkg/contrib/srvrec.h
+++ b/apt-pkg/contrib/srvrec.h
@@ -9,6 +9,7 @@
 #ifndef SRVREC_H
 #define SRVREC_H
 
+#include <sys/types.h>
 #include <string>
 #include <vector>
 #include <arpa/nameser.h>

--- a/methods/connect.cc
+++ b/methods/connect.cc
@@ -32,6 +32,10 @@
 #include <unistd.h>
 
 // Internet stuff
+#ifndef AI_IDN
+#define AI_IDN 0x0040
+#endif
+
 #include <netdb.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>


### PR DESCRIPTION
Rebase 0001-apt-1.2.12-Fix-musl-build.patch to apt 1.8.
The 0001-apt-1.2.12-Fix-musl-build.patch fetched from following url.

URL: https://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta/recipes-devtools/apt/apt/0001-apt-1.2.12-Fix-musl-build.patch?id=753e2a0ede4449917c75353b57f13bbafe70fac8