### PR TITLE
Rebase 0001-Include-array.h-for-std-array.patch

### DIFF
--- a/apt-pkg/contrib/strutl.cc
+++ b/apt-pkg/contrib/strutl.cc
@@ -20,6 +20,7 @@
 #include <apt-pkg/fileutl.h>
 #include <apt-pkg/strutl.h>
 
+#include <array>
 #include <algorithm>
 #include <array>
 #include <iomanip>


### PR DESCRIPTION
Rebase 0001-Include-array.h-for-std-array.patch to apt 1.8.
This rebase is based on following file.

URL: https://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta/recipes-devtools/apt/apt/0001-Include-array.h-for-std-array.patch?id=753e2a0ede4449917c75353b57f13bbafe70fac8