### PR TITLE
Create disable-test.patch from poky

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,6 @@ cmake_minimum_required(VERSION 3.4.0)
 include_directories(${PROJECT_BINARY_DIR}/include)
 
 
-enable_testing()
-
 option(WITH_DOC "Build documentation." OFF)
 option(USE_NLS "Localisation support." OFF)
 
@@ -230,7 +228,6 @@ add_subdirectory(completions)
 add_subdirectory(dselect)
 add_subdirectory(ftparchive)
 add_subdirectory(methods)
-add_subdirectory(test)
 
 if (USE_NLS)
 add_subdirectory(po)


### PR DESCRIPTION
Poky's disable-test.patch is against old build system so that this commit implement disable-test.patch to apt 1.8
This implementation is based on following url.
https://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta/recipes-devtools/apt/apt/disable-test.patch?id=753e2a0ede4449917c75353b57f13bbafe70fac8