### PR TITLE
Use local iconv.h instead of libc's

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,6 @@ include(GNUInstallDirs)
 include(TestBigEndian)
 find_package(Threads REQUIRED)
 find_package(LFS REQUIRED)
-find_package(Iconv REQUIRED)
 
 find_package(Perl REQUIRED)
 

--- a/apt-pkg/CMakeLists.txt
+++ b/apt-pkg/CMakeLists.txt
@@ -47,6 +47,7 @@ target_include_directories(apt-pkg
                                    $<$<BOOL:${ZSTD_FOUND}>:${ZSTD_INCLUDE_DIRS}>
                                    $<$<BOOL:${UDEV_FOUND}>:${UDEV_INCLUDE_DIRS}>
                                    ${ICONV_INCLUDE_DIRS}
+	                           contrib
 )
 
 target_link_libraries(apt-pkg

--- a/apt-pkg/contrib/iconv.h
+++ b/apt-pkg/contrib/iconv.h
@@ -1,0 +1,55 @@
+/* Copyright (C) 1997-2018 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#ifndef _ICONV_H
+#define _ICONV_H	1
+
+#include <features.h>
+#define __need_size_t
+#include <stddef.h>
+
+
+__BEGIN_DECLS
+
+/* Identifier for conversion method from one codeset to another.  */
+typedef void *iconv_t;
+
+
+/* Allocate descriptor for code conversion from codeset FROMCODE to
+   codeset TOCODE.
+
+   This function is a possible cancellation point and therefore not
+   marked with __THROW.  */
+extern iconv_t iconv_open (const char *__tocode, const char *__fromcode);
+
+/* Convert at most *INBYTESLEFT bytes from *INBUF according to the
+   code conversion algorithm specified by CD and place up to
+   *OUTBYTESLEFT bytes in buffer at *OUTBUF.  */
+extern size_t iconv (iconv_t __cd, char **__restrict __inbuf,
+		     size_t *__restrict __inbytesleft,
+		     char **__restrict __outbuf,
+		     size_t *__restrict __outbytesleft);
+
+/* Free resources allocated for descriptor CD for code conversion.
+
+   This function is a possible cancellation point and therefore not
+   marked with __THROW.  */
+extern int iconv_close (iconv_t __cd);
+
+__END_DECLS
+
+#endif /* iconv.h */


### PR DESCRIPTION
Poky doesn't provide libconv for native target[1]. So when build apt
for native target, cmake fails because there is no iconv.h in
recipes-sysroot-native.

Therefore add iconv.h in apt-pkg/contrib directory to include it
instead of read fron /usr/include.

The iconv.h is copied from libc6-dev 2.28-8.

[1]: https://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta/recipes-core/glibc/glibc.inc?h=warrior&id=3dd005248f56aa774631d6bb868b1f7328d57f3c