### PR TITLE
Rebase patch to 1.8.0

### DIFF
--- a/apt-pkg/contrib/strutl.cc
+++ b/apt-pkg/contrib/strutl.cc
@@ -28,6 +28,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <array>
 
 #include <ctype.h>
 #include <errno.h>


### PR DESCRIPTION
Rebase gcc_4.x_apt-pkg-contrib-strutl.cc-Include-array-header.patch
patch to 1.8.0.

poky rev: ffac131f1f03dd26ff65dd32918e940350e5e305
file: gcc_4.x_apt-pkg-contrib-strutl.cc-Include-array-header.patch
url:
https://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta/recipes-devtools/apt/apt/gcc_4.x_apt-pkg-contrib-strutl.cc-Include-array-header.patch?h=warrior&id=ffac131f1f03dd26ff65dd32918e940350e5e305