### PR TITLE
Rebase gcc version check patch to 1.8.0

### DIFF
--- a/apt-pkg/contrib/macros.h
+++ b/apt-pkg/contrib/macros.h
@@ -137,7 +137,7 @@
 #endif
 #endif
 
-#if __GNUC__ >= 4
+#if __GNUC__ >= 4 + (6 >= __GNUC_MINOR__)
 	#define APT_IGNORE_DEPRECATED_PUSH \
 		_Pragma("GCC diagnostic push") \
 		_Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")

--- a/apt-pkg/deb/debsrcrecords.cc
+++ b/apt-pkg/deb/debsrcrecords.cc
@@ -166,13 +166,13 @@ bool debSrcRecordParser::Files(std::vector<pkgSrcRecords::File> &F)
    for (std::vector<pkgSrcRecords::File2>::const_iterator f2 = F2.begin(); f2 != F2.end(); ++f2)
    {
       pkgSrcRecords::File2 f;
-#if __GNUC__ >= 4
+#if __GNUC__ >= 4 + (6 >= __GNUC_MINOR__)
 	#pragma GCC diagnostic push
 	#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
       f.MD5Hash = f2->MD5Hash;
       f.Size = f2->Size;
-#if __GNUC__ >= 4
+#if __GNUC__ >= 4 + (6 >= __GNUC_MINOR__)
 	#pragma GCC diagnostic pop
 #endif
       f.Path = f2->Path;

--- a/apt-pkg/srcrecords.cc
+++ b/apt-pkg/srcrecords.cc
@@ -158,7 +158,7 @@ bool pkgSrcRecords::Parser::Files2(std::vector<pkgSrcRecords::File2> &F2)/*{{{*/
    for (std::vector<pkgSrcRecords::File>::const_iterator f = F.begin(); f != F.end(); ++f)
    {
       pkgSrcRecords::File2 f2;
-#if __GNUC__ >= 4
+#if __GNUC__ >= 4 + (6 >= __GNUC_MINOR__)
 	#pragma GCC diagnostic push
 	#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
@@ -166,7 +166,7 @@ bool pkgSrcRecords::Parser::Files2(std::vector<pkgSrcRecords::File2> &F2)/*{{{*/
       f2.Size = f->Size;
       f2.Hashes.push_back(HashString("MD5Sum", f->MD5Hash));
       f2.FileSize = f->Size;
-#if __GNUC__ >= 4
+#if __GNUC__ >= 4 + (6 >= __GNUC_MINOR__)
 	#pragma GCC diagnostic pop
 #endif
       f2.Path = f->Path;


### PR DESCRIPTION
Rebase 0001-fix-the-gcc-version-check.patch to apt 1.8.0

poky rev: ffac131f1f03dd26ff65dd32918e940350e5e305
file: 0001-fix-the-gcc-version-check.patch
url: https://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta/recipes-devtools/apt/apt/0001-fix-the-gcc-version-check.patch?h=warrior&id=ffac131f1f03dd26ff65dd32918e940350e5e305