### PR TITLE
Rebase noconfigure.patch to 1.8.0

### DIFF
--- a/apt-pkg/packagemanager.cc
+++ b/apt-pkg/packagemanager.cc
@@ -1013,10 +1013,12 @@ bool pkgPackageManager::SmartUnPack(PkgIterator Pkg, bool const Immediate, int c
       return false;
 
    if (Immediate == true) {
+#if 0	   
       // Perform immediate configuration of the package. 
          if (SmartConfigure(Pkg, Depth + 1) == false)
             _error->Error(_("Could not perform immediate configuration on '%s'. "
                "Please see man 5 apt.conf under APT::Immediate-Configure for details. (%d)"),Pkg.FullName().c_str(),2);
+#endif	 
    }
    
    return true;
@@ -1111,6 +1113,7 @@ pkgPackageManager::OrderResult pkgPackageManager::OrderInstall()
       }
    }
 
+#if 0   
    // Final run through the configure phase
    if (ConfigureAll() == false)
       return Failed;
@@ -1125,7 +1128,7 @@ pkgPackageManager::OrderResult pkgPackageManager::OrderInstall()
 	 return Failed;
       }
    }
-	 
+#endif	 
    return Completed;
 }
 // PM::DoInstallPostFork - compat /*{{{*/


### PR DESCRIPTION
Rebase noconfigure.patch to apt 1.8.0

poky rev: ffac131f1f03dd26ff65dd32918e940350e5e305
file: noconfigure.patch
url: https://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta/recipes-devtools/apt/apt/noconfigure.patch?h=warrior&id=ffac131f1f03dd26ff65dd32918e940350e5e305